### PR TITLE
Fixes output file to only include rolling prompt

### DIFF
--- a/FredRalph_p1.toml
+++ b/FredRalph_p1.toml
@@ -1,7 +1,12 @@
 [debate_params]
 speaker1_fullname = "Frederich Nietzsche"
 speaker2_fullname = "Ralph Waldo Emerson"
-initial_prompt = "You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.\n\nFrederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.\nRalph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.\nFrederich: "
+initial_prompt = """
+You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.
+
+Frederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.
+Ralph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.
+"""
 rounds = 5
 
 [model_params]

--- a/FredRalph_p2.toml
+++ b/FredRalph_p2.toml
@@ -1,7 +1,12 @@
 [debate_params]
 speaker1_fullname = "Frederich Nietzsche"
 speaker2_fullname = "Ralph Waldo Emerson"
-initial_prompt = "You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.\n\nFrederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.\nRalph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.\nFrederich: "
+initial_prompt = """
+You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.
+
+Frederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.
+Ralph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.
+"""
 rounds = 15
 
 [model_params]

--- a/FredRalph_p3.toml
+++ b/FredRalph_p3.toml
@@ -1,7 +1,12 @@
 [debate_params]
 speaker1_fullname = "Frederich Nietzsche"
 speaker2_fullname = "Ralph Waldo Emerson"
-initial_prompt = "You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.\n\nFrederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.\nRalph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.\nFrederich: "
+initial_prompt = """
+You are the philosopher Frederich Nietzsche and you are having a conversation with your friend and fellow philosopher Ralph Waldo Emerson. You emphatically put forward your thoughts in each exchange, sometimes giving an original thought, sometimes challenging your friend's previous utterance.
+
+Frederich: God is dead and we have murdered him, what is left is gaping hole into which nihilism will find cover.
+Ralph: Indeed, for great is paint and God is the painter, we rightly accuse the the critic who destroys too many illusions, but maybe we have given the critic too free a reign in deconstructing age-old shibboleths.
+"""
 rounds = 15
 
 [model_params]


### PR DESCRIPTION
 - Fixes output bug
 - Simplifies` the "get_next_speaker" function
 - Adds a function "get_last_utterance"
 - Also added multi-line strings to the TOML files to make the prompt easier to read (instead of having one super long line) 
   - I made a change here which makes the code cleaner: before, in the TOML, the initial_prompt ended with `Frederich: ` , ready for the next prompt. I've removed this and , instead, I just call get_new_prompt  in the main function before doing anything.
    - This change makes it easier/cleaner when defining all_outputs which is written to the output file at the end